### PR TITLE
Upgrade to NodeJS 20

### DIFF
--- a/.changeset/short-files-carry.md
+++ b/.changeset/short-files-carry.md
@@ -1,0 +1,5 @@
+---
+"docker-node-java-jena": major
+---
+
+Upgrade Node to 20

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/library/ubuntu:22.04
 
 ENV DEBIAN_FRONTEND="noninteractive"
-ENV NODE_VERSION="18"
+ENV NODE_VERSION="20"
 ENV EYE_VERSION="9.6.5"
 ENV JENA_VERSION="4.10.0"
 


### PR DESCRIPTION
This upgrades to the current NodeJS LTS.

We should trigger a new major release as it may break some pipelines.