### PR TITLE
Include missing Apache Jena tools

### DIFF
--- a/.changeset/spotty-tips-yell.md
+++ b/.changeset/spotty-tips-yell.md
@@ -1,0 +1,5 @@
+---
+"docker-node-java-jena": patch
+---
+
+Add missing Apache Jena tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dear
 RUN npm install -g barnard59
 
 # install Apache Jena tools
-RUN curl -fsSL "https://dlcdn.apache.org/jena/binaries/apache-jena-fuseki-${JENA_VERSION}.tar.gz" | tar zxf - \
+RUN curl -fsSL "https://dlcdn.apache.org/jena/binaries/apache-jena-${JENA_VERSION}.tar.gz" | tar zxf - \
   && mv apache-jena* /jena \
   && rm -f jena.tar.gz* \
   && cd /jena && rm -rf *javadoc* *src* bat


### PR DESCRIPTION
This fixes the Docker image to include the `riot` tools and other Apache Jena tools.