### PR TITLE
Add Minio client (`mc`)

### DIFF
--- a/.changeset/funny-cheetahs-pay.md
+++ b/.changeset/funny-cheetahs-pay.md
@@ -1,0 +1,5 @@
+---
+"docker-node-java-jena": minor
+---
+
+Add `mc` (Minio client) CLI

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,14 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dear
   && apt-get install -y nodejs \
   && apt-get clean
 
+# Install Minio client
+COPY --from=minio/mc:latest /usr/bin/mc /usr/bin/mc
+
 # install barnard59 globally
 RUN npm install -g barnard59
 
 # install Apache Jena tools
-RUN curl -fsSL "https://dlcdn.apache.org/jena/binaries/apache-jena-${JENA_VERSION}.tar.gz" | tar zxf - \
+RUN curl -fsSL "https://archive.apache.org/dist/jena/binaries/apache-jena-${JENA_VERSION}.tar.gz" | tar zxf - \
   && mv apache-jena* /jena \
   && rm -f jena.tar.gz* \
   && cd /jena && rm -rf *javadoc* *src* bat


### PR DESCRIPTION
This adds the Minio client CLI in the Docker image.
Use `mc` to use it.

Reference: https://min.io/docs/minio/linux/reference/minio-mc.html